### PR TITLE
Comment out pry call

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -46,7 +46,7 @@ def extract_detail(page)
     when id = @mappings.keys.find {|matcher| k.match(matcher)}
       details.merge!({@mappings[id] => scrub(value.text)})
     else
-      binding.pry
+      #binding.pry
       raise "unknown field for '#{k}'"
     end
   end


### PR DESCRIPTION
We don't want to invoke pry when running for realz.

This was causing the scraper to get stuck running on morph.io for 24 hours.
